### PR TITLE
DM-54533 Replace enqueue webhook with Kafka consumer

### DIFF
--- a/Dockerfile.enqueue
+++ b/Dockerfile.enqueue
@@ -22,11 +22,11 @@
 # Dockerfile for enqueue service.
 
 FROM python:3.11
-RUN pip install redis gunicorn flask
+RUN pip install redis aiokafka
 WORKDIR /enqueue
 COPY src/enqueue.py src/info.py src/utils.py /enqueue/
 # environment variables that must be set:
-# REDIS_HOST REDIS_PASSWORD NOTIFICATION_SECRET
+# REDIS_HOST REDIS_PASSWORD KAFKA_CLUSTER KAFKA_TOPIC
 # optional:
-# DATASET_REGEXP
-ENTRYPOINT [ "gunicorn", "-b", "0.0.0.0:8000", "-w", "2", "enqueue:app" ]
+# DATASET_REGEXP PROFILE KAFKA_GROUP_ID KAFKA_OFFSET_RESET
+ENTRYPOINT [ "python", "enqueue.py" ]

--- a/src/enqueue.py
+++ b/src/enqueue.py
@@ -21,14 +21,20 @@
 
 """
 Enqueue service to post notifications to per-bucket queues.
+
+Consumes S3 ObjectCreated notifications that Ceph RGW publishes (as plain
+JSON) to a Kafka topic, and pushes the resulting object paths onto per-bucket
+Redis queues for the ingest workers.
 """
+import asyncio
+import json
 import os
 import re
 import time
 import urllib.parse
 
+import aiokafka
 import redis
-from flask import Flask, request
 
 from info import ExposureInfo, Info
 from utils import setup_logging, setup_redis
@@ -38,7 +44,6 @@ FILE_RETENTION: float = 7 * 24 * 60 * 60
 
 logger = setup_logging(__name__)
 r = setup_redis()
-notification_secret = os.environ["NOTIFICATION_SECRET"]
 regexp = re.compile(os.environ.get("DATASET_REGEXP", r"fits$"))
 profile = os.environ.get("PROFILE", "")
 if profile != "":
@@ -49,7 +54,9 @@ def enqueue_objects(objects):
     """Enqueue objects onto per-bucket queues.
 
     Compute the `Info` for each object with a selected extension and return
-    the list.
+    the list.  Paths that have already been enqueued within the
+    ``FILE_RETENTION`` window are skipped, so Kafka redeliveries (rebalance,
+    pod restart) and operator re-trigger tooling do not double-enqueue.
 
     Parameters
     ----------
@@ -63,11 +70,17 @@ def enqueue_objects(objects):
     # Use a pipeline for efficiency.
     with r.pipeline() as pipe:
         for o in objects:
-            if regexp.search(o):
-                info = Info.from_path(o)
-                pipe.lpush(f"QUEUE:{info.bucket}", o)
-                logger.info("Enqueued %s to %s", o, info.bucket)
-                info_list.append(info)
+            if not regexp.search(o):
+                continue
+            # SET NX EX is the dedupe guard; pipeline can't conditionally
+            # enqueue, so this is a separate round trip per matched object.
+            if not r.set(f"ENQ:{o}", "1", nx=True, ex=int(FILE_RETENTION)):
+                logger.info("Skipping duplicate enqueue %s", o)
+                continue
+            info = Info.from_path(o)
+            pipe.lpush(f"QUEUE:{info.bucket}", o)
+            logger.info("Enqueued %s to %s", o, info.bucket)
+            info_list.append(info)
         pipe.execute()
     return info_list
 
@@ -111,19 +124,94 @@ def update_stats(info_list):
                     continue
 
 
-app = Flask(__name__)
+def object_names_from_notification(payload):
+    """Extract object names from an S3 bucket notification message.
 
+    Ceph RGW publishes notifications to Kafka as plain JSON in the standard
+    S3 event-notification schema.  Records that aren't ``ObjectCreated*`` are
+    skipped, as are records that are missing required fields.
 
-@app.post("/notify")
-def notify():
+    Parameters
+    ----------
+    payload: `bytes` or `str`
+        The raw Kafka message value.
+
+    Returns
+    -------
+    object_names: `list` [`str`]
+        ``profile + bucket + "/" + key`` strings ready for `Info.from_path`.
+    """
     object_names = []
-    for r in request.json["Records"]:
-        if r["opaqueData"] != notification_secret:
-            logger.info("Unrecognized secret %s", r["opaqueData"])
+    msg = json.loads(payload)
+    for record in msg.get("Records", []):
+        if not record.get("eventName", "").startswith("ObjectCreated"):
             continue
-        object_names.append(
-            profile + r["s3"]["bucket"]["name"] + "/" + urllib.parse.unquote_plus(r["s3"]["object"]["key"])
-        )
-    info_list = enqueue_objects(object_names)
-    update_stats(info_list)
-    return info_list
+        try:
+            bucket = record["s3"]["bucket"]["name"]
+            key = urllib.parse.unquote_plus(record["s3"]["object"]["key"])
+        except (KeyError, TypeError):
+            logger.exception("Invalid S3 notification record: %s", record)
+            continue
+        object_names.append(profile + bucket + "/" + key)
+    return object_names
+
+
+async def main():
+    """Consume S3 notifications from Kafka and enqueue objects on Redis.
+
+    Offsets are committed manually after a message has been successfully
+    processed (parse + ``enqueue_objects`` + ``update_stats``).  Parse-stage
+    failures (malformed JSON, ``None`` tombstone) are treated as poison pills
+    and committed so they don't block the partition; process-stage failures
+    (e.g. Redis errors) deliberately leave the offset uncommitted so the
+    message is redelivered on the next poll or after a pod restart.
+    """
+    consumer = aiokafka.AIOKafkaConsumer(
+        os.environ["KAFKA_TOPIC"],
+        bootstrap_servers=os.environ["KAFKA_CLUSTER"],
+        group_id=os.environ.get("KAFKA_GROUP_ID", "embargo-butler-enqueue"),
+        auto_offset_reset=os.environ.get("KAFKA_OFFSET_RESET", "latest"),
+        enable_auto_commit=False,
+    )
+    await consumer.start()
+    logger.info(
+        "Kafka consumer started: topic=%s cluster=%s group=%s",
+        os.environ["KAFKA_TOPIC"],
+        os.environ["KAFKA_CLUSTER"],
+        os.environ.get("KAFKA_GROUP_ID", "embargo-butler-enqueue"),
+    )
+    try:
+        async for msg in consumer:
+            try:
+                object_names = object_names_from_notification(msg.value)
+            except (AttributeError, TypeError, ValueError, UnicodeDecodeError):
+                logger.exception(
+                    "Skipping malformed Kafka message topic=%s partition=%s offset=%s",
+                    msg.topic,
+                    msg.partition,
+                    msg.offset,
+                )
+                await consumer.commit()
+                continue
+
+            try:
+                if object_names:
+                    info_list = enqueue_objects(object_names)
+                    update_stats(info_list)
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue Kafka message topic=%s partition=%s offset=%s; "
+                    "leaving offset uncommitted for redelivery",
+                    msg.topic,
+                    msg.partition,
+                    msg.offset,
+                )
+                continue
+
+            await consumer.commit()
+    finally:
+        await consumer.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/enqueue.py
+++ b/src/enqueue.py
@@ -42,6 +42,16 @@ from utils import setup_logging, setup_redis
 FILE_RETENTION: float = 7 * 24 * 60 * 60
 """Time in seconds to remember information about specific FITS files."""
 
+ENQUEUE_DEDUPE_TTL: int = 24 * 60 * 60
+"""Time in seconds an ``ENQ:<path>`` dedupe marker survives.
+
+Matches the Kafka topic retention so Kafka redeliveries (rebalance, restart-
+with-uncommitted-offset) are always deduped, while operators can force a
+re-enqueue of an older path either by waiting out the window or by deleting
+the ``ENQ:<path>`` key explicitly (see the manual trigger script's
+``--force`` flag in ``usdf-embargo-deploy``).
+"""
+
 logger = setup_logging(__name__)
 r = setup_redis()
 regexp = re.compile(os.environ.get("DATASET_REGEXP", r"fits$"))
@@ -55,8 +65,9 @@ def enqueue_objects(objects):
 
     Compute the `Info` for each object with a selected extension and return
     the list.  Paths that have already been enqueued within the
-    ``FILE_RETENTION`` window are skipped, so Kafka redeliveries (rebalance,
-    pod restart) and operator re-trigger tooling do not double-enqueue.
+    ``ENQUEUE_DEDUPE_TTL`` window are skipped, so Kafka redeliveries
+    (rebalance, pod restart) and operator re-trigger tooling do not
+    double-enqueue.
 
     Parameters
     ----------
@@ -74,7 +85,7 @@ def enqueue_objects(objects):
                 continue
             # SET NX EX is the dedupe guard; pipeline can't conditionally
             # enqueue, so this is a separate round trip per matched object.
-            if not r.set(f"ENQ:{o}", "1", nx=True, ex=int(FILE_RETENTION)):
+            if not r.set(f"ENQ:{o}", "1", nx=True, ex=ENQUEUE_DEDUPE_TTL):
                 logger.info("Skipping duplicate enqueue %s", o)
                 continue
             info = Info.from_path(o)

--- a/src/enqueue.py
+++ b/src/enqueue.py
@@ -60,37 +60,47 @@ if profile != "":
     profile += "@"
 
 
-def enqueue_objects(objects):
-    """Enqueue objects onto per-bucket queues.
+def enqueue_objects(object_names):
+    """Enqueue object paths onto per-bucket Redis queues.
 
-    Compute the `Info` for each object with a selected extension and return
-    the list.  Paths that have already been enqueued within the
-    ``ENQUEUE_DEDUPE_TTL`` window are skipped, so Kafka redeliveries
-    (rebalance, pod restart) and operator re-trigger tooling do not
-    double-enqueue.
+    For each path that matches the ``DATASET_REGEXP`` filter (default
+    ``fits$``), compute its `Info`, push the path onto ``QUEUE:<bucket>``
+    for the ingest workers, and accumulate the resulting `Info` for the
+    returned list.  Paths not matching the regexp are silently skipped, as
+    are paths whose ``ENQ:<path>`` dedupe marker is still live (set with
+    ``ENQUEUE_DEDUPE_TTL``), so Kafka redeliveries (rebalance, pod
+    restart) and operator re-trigger tooling do not double-enqueue.
 
     Parameters
     ----------
-    objects: `list` [`str`]
+    object_names: `list` [`str`]
+        S3 object paths of the form ``[profile@]bucket/key`` -- i.e. the
+        notification's bucket name and object key joined with ``"/"`` and
+        optionally prefixed with the configured ``PROFILE@``, as produced
+        by `object_names_from_notification` and consumed by
+        `Info.from_path`.
 
     Returns
     -------
     info_list: `list` [`Info`]
+        One `Info` per object that was newly enqueued (regexp-matched and
+        not a duplicate).  Objects filtered out by the regexp or the
+        dedupe guard do not appear in this list.
     """
     info_list = []
     # Use a pipeline for efficiency.
     with r.pipeline() as pipe:
-        for o in objects:
-            if not regexp.search(o):
+        for name in object_names:
+            if not regexp.search(name):
                 continue
             # SET NX EX is the dedupe guard; pipeline can't conditionally
             # enqueue, so this is a separate round trip per matched object.
-            if not r.set(f"ENQ:{o}", "1", nx=True, ex=ENQUEUE_DEDUPE_TTL):
-                logger.info("Skipping duplicate enqueue %s", o)
+            if not r.set(f"ENQ:{name}", "1", nx=True, ex=ENQUEUE_DEDUPE_TTL):
+                logger.info("Skipping duplicate enqueue %s", name)
                 continue
-            info = Info.from_path(o)
-            pipe.lpush(f"QUEUE:{info.bucket}", o)
-            logger.info("Enqueued %s to %s", o, info.bucket)
+            info = Info.from_path(name)
+            pipe.lpush(f"QUEUE:{info.bucket}", name)
+            logger.info("Enqueued %s to %s", name, info.bucket)
             info_list.append(info)
         pipe.execute()
     return info_list


### PR DESCRIPTION
- Drop Flask /notify endpoint, gunicorn entrypoint, and NOTIFICATION_SECRET.
- Consume RGW S3 ObjectCreated notifications (plain JSON, no Avro/SASL -- matches the pattern in lsst-dm/prompt_processing activator.py) via an aiokafka.AIOKafkaConsumer driven by asyncio.run(main()).
- Add object_names_from_notification() that filters ObjectCreated:* events and maps records to "<profile><bucket>/<urldecoded key>" for Info.from_path.
- Idempotent enqueue: SET NX EX ENQ:<path> guard before lpush so Kafka redelivery (rebalance, pod restart) and operator re-trigger tooling do not double-enqueue. Skipped duplicates log "Skipping duplicate enqueue". The existing "Enqueued <path> to <bucket>" line is preserved so existing Loki gap-detection scripts continue to parse cleanly.
- At-least-once: enable_auto_commit=False with a two-stage try block -- parse failures (malformed JSON, tombstones) are committed as poison pills; process failures (Redis errors) leave the offset uncommitted so the message is redelivered on next poll or after pod restart.
- Dockerfile.enqueue: drop gunicorn/flask, add aiokafka; entrypoint is now a plain Python process. Required env: REDIS_HOST REDIS_PASSWORD KAFKA_CLUSTER KAFKA_TOPIC. Optional: DATASET_REGEXP PROFILE KAFKA_GROUP_ID KAFKA_OFFSET_RESET.