### PR TITLE
Fix ingest worker crash on idle queue with redis-py >= 5

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -29,6 +29,7 @@ import socket
 import time
 
 import astropy.io.fits
+import redis
 import requests
 from lsst.daf.butler import Butler
 from lsst.obs.base import DefineVisitsTask, RawIngestTask
@@ -386,8 +387,18 @@ def main():
         n = r.llen(worker_queue)
         if n == 0:
             # Atomically grab the next entry from the bucket queue, blocking
-            # until one exists.
-            r.blmove(redis_queue, worker_queue, 0, "RIGHT", "LEFT")
+            # until one exists.  A finite block timeout is required rather than
+            # an infinite BLMOVE: redis-py >= 5 (shipped in lsst-scipipe-13)
+            # enforces a socket read timeout on blocking commands, so an
+            # infinite BLMOVE (timeout=0) raises TimeoutError on an idle queue.
+            # Retry on both the None (timeout expiry) and TimeoutError results
+            # until an entry arrives.
+            while True:
+                try:
+                    if r.blmove(redis_queue, worker_queue, 5, "RIGHT", "LEFT") is not None:
+                        break
+                except redis.exceptions.TimeoutError:
+                    continue
             n = 1
 
         # Be greedy and take as many entries as exist up to max


### PR DESCRIPTION
## Summary
- The ingest worker blocks on an empty bucket queue with `BLMOVE(timeout=0)` (`src/ingest.py`).
- Under the `1.6` image (rubinenv `13.0.0` → redis-py >= 5, RESP3), blocking commands enforce a socket read timeout, so the infinite `BLMOVE` raises `redis.exceptions.TimeoutError` on an idle queue. The worker exits 1 and CrashLoopBackOffs every time the queue drains — observed in prod `summit-new` as all 8 ingest pods flapping. `v1.5` was unaffected (older redis-py blocked indefinitely).
- Fix: use a finite 5s block timeout in a retry loop and swallow `TimeoutError`, so the worker waits indefinitely for new work without exceeding the socket read timeout.